### PR TITLE
Fix enum syntax deprecation warning for newer Ruby versions

### DIFF
--- a/lib/followability/relationship.rb
+++ b/lib/followability/relationship.rb
@@ -4,7 +4,7 @@ module Followability
   class Relationship < ActiveRecord::Base
     STATUSES = %i[requested blocked following].freeze
 
-    enum status: STATUSES
+    enum :status, STATUSES
 
     validates :status, presence: true
 


### PR DESCRIPTION
Updates enum declaration to the recommended syntax to avoid deprecation warnings on newer Ruby/Rails versions.

No behavior change intended.
